### PR TITLE
fix: problematic asterisk operator computation

### DIFF
--- a/src/pdg_js/js_operators.py
+++ b/src/pdg_js/js_operators.py
@@ -545,7 +545,12 @@ def operator_minus(a, b):
 
 def operator_asterisk(a, b):
     """ Evaluates a * b. """
-    return a * b
+    try:
+        a = float(a)
+        b = float(b)
+        return a * b
+    except (ValueError, TypeError):
+        return None
 
 
 def operator_slash(a, b):


### PR DESCRIPTION
### Problem
In JavaScript, the operation `*` of a number and a string that cannot be parsed into a number results in `NaN`, whereas in Python, the result is a string consisting of the original string repeated by the number used in the operation.
This discrepency in operator behaviour between the languages can cause memory issues, if the resulting string is very large.

### Solution
This PR aims to eliminate the problematic case and improve the behaviour simulation of JavaScript for the `*` operation while not impeding the performance.

### Refactor Suggestion
As there are also differences in behaviour for various other operators, a refactor of the `compute_operators` function could be considered. A PoC, that computes the operators via JavaScript using [PyMiniRacer](https://github.com/sqreen/PyMiniRacer) can be found here: https://github.com/Aurore54F/DoubleX/compare/main...Falanty:DoubleX:feat/js_operator_calculation_with_js_context.